### PR TITLE
Fixes typo for clear-package-data argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function invoke() {
     }
 
     if (clearPackageData) {
-      args.push('--clearpackage-data');
+      args.push('--clear-package-data');
     }
 
     if (withCoverage) {


### PR DESCRIPTION
Self-explained!

Bug caught during [this Workflow run](https://github.com/dotanuki-labs/norris/runs/3982424053?check_suite_focus=true#step:3:28) (related [PR](https://github.com/dotanuki-labs/norris/pull/368))

```
Unknown option --clearpackage-data
Usage: ew-cli options_list
```

Not sure if `ew-cli` should exit with **status == 0** in the case of unknown arguments (since I'm not aware if this was intended) but for sure it would be useful having **status != 0**  for the sake of GHA / CI executions 🙂

